### PR TITLE
Improve UI: card items, culture badges, sidebar, and search bar polish

### DIFF
--- a/src/components/AutoCompleteInput/AutoCompleteInput.scss
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.scss
@@ -1,18 +1,9 @@
 .auto-complete-list-class-name {
-  background-color: wheat;
   display: none;
   position: absolute;
   z-index: 2000;
+
   &.show {
     display: block;
-  }
-
-  li {
-    &.selected {
-      background-color: yellow;
-    }
-    span.typed {
-      background-color: yellow;
-    }
   }
 }

--- a/src/features/home/HomePage.scss
+++ b/src/features/home/HomePage.scss
@@ -1,68 +1,113 @@
-$setting-width: 130px;
+$setting-width: 160px;
 
 @keyframes sidebar-in {
     0% {
         right: -$setting-width;
+        opacity: 0;
     }
 
     100% {
         right: 0px;
+        opacity: 1;
     }
 }
 
 @keyframes sidebar-out {
     0% {
         right: 0px;
+        opacity: 1;
     }
 
     100% {
         right: -$setting-width;
+        opacity: 0;
     }
 }
 
 .wrapper {
-    margin: 2px;
+    margin: 4px;
 }
-
 
 .content {
     width: 100%;
     padding-right: 0px;
-    transition: all 0.5s ease;
+    transition: padding-right 0.4s ease;
 }
 
 .wrapper.toggled .content {
     padding-right: $setting-width;
-    transition: all 0.5s ease;
+    transition: padding-right 0.4s ease;
 }
 
-
 .sidebar {
-    padding: 10px;
+    padding: 12px 10px;
     position: absolute;
     display: none;
     width: $setting-width;
     top: 0px;
     right: -$setting-width;
+    border-left: 1px solid #e8e8e8;
+    background-color: #fafafa;
+    min-height: 100vh;
     animation-name: sidebar-out;
-    animation-duration: 0.5s;
+    animation-duration: 0.4s;
 }
 
 .wrapper.toggled .sidebar {
     display: block;
     right: 0px;
     animation-name: sidebar-in;
-    animation-duration: 0.5s;
+    animation-duration: 0.4s;
+}
+
+// Sidebar config button group
+.sidebar {
+  .btn-group-vertical {
+    width: 100%;
+
+    .btn {
+      font-size: 0.8rem;
+      padding: 0.4rem 0.6rem;
+      border-radius: 5px !important;
+      margin-bottom: 4px;
+      border: 1px solid #dee2e6;
+      text-align: left;
+
+      &.btn-outline-secondary {
+        color: #495057;
+        border-color: #dee2e6;
+        background-color: #fff;
+
+        &:hover {
+          background-color: #f0f4ff;
+          border-color: #b8c9f0;
+          color: #1a56db;
+        }
+      }
+
+      &.btn-outline-danger {
+        &:hover {
+          background-color: #fff5f5;
+        }
+      }
+    }
+  }
+
+  hr {
+    margin: 8px 0;
+    border-color: #e8e8e8;
+  }
 }
 
 .version-badge {
     position: fixed;
-    bottom: 10px;
-    right: 10px;
-    font-size: 12px;
-    color: #999;
+    bottom: 8px;
+    right: 8px;
+    font-size: 11px;
+    color: #bbb;
     background-color: transparent;
-    padding: 4px 8px;
+    padding: 2px 6px;
     border-radius: 4px;
     pointer-events: none;
+    letter-spacing: 0.02em;
 }

--- a/src/features/search/Search.scss
+++ b/src/features/search/Search.scss
@@ -1,15 +1,21 @@
+.search-header {
+  padding: 6px 0 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
 // Bootstrap's warning color value
 $warning-color: #ffc107;
+$phrase-bg: #fafcf3;
+$item-bg: #fffffb;
+$item-border: #e0dede;
+$item-hover-border: #c8c5c5;
+$culture-color: #b0b0b0;
 
 .input-group {
   max-width: 800px;
   min-width: 300px;
   align-self: center;
-  .input-group-text {
-    background-color: white;
-    border-color: #6c757d;
-    border-radius: 8px;
-  }
+
   .auto-complete {
     position: relative;
     border-radius: 0;
@@ -33,7 +39,7 @@ $warning-color: #ffc107;
       background-clip: padding-box;
       border: 1px solid #ced4da;
       appearance: none;
-      transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+      transition: border-color 0.15s ease-in-out;
 
       &:focus {
         color: #212529;
@@ -50,9 +56,10 @@ $warning-color: #ffc107;
       flex-direction: column;
       padding-left: 0;
       margin-bottom: 0;
-      border-radius: 0.25rem;
+      border-radius: 6px;
       background-color: #fff;
-      border: 1px solid rgba(0, 0, 0, 0.15);
+      border: 1px solid rgba(0, 0, 0, 0.12);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       max-height: 300px;
       overflow-y: auto;
       width: auto;
@@ -61,47 +68,52 @@ $warning-color: #ffc107;
       &.show {
         display: flex;
       }
-      
+
       li {
         position: relative;
         display: block;
-        padding: 0.5rem 1rem;
+        padding: 0.45rem 0.9rem;
         color: #212529;
         text-decoration: none;
         background-color: #fff;
-        border: 1px solid rgba(0, 0, 0, 0.125);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.06);
         cursor: pointer;
+        font-size: 0.9rem;
 
         &:first-child {
-          border-top-left-radius: inherit;
-          border-top-right-radius: inherit;
+          border-top-left-radius: 6px;
+          border-top-right-radius: 6px;
         }
 
         &:last-child {
-          border-bottom-right-radius: inherit;
-          border-bottom-left-radius: inherit;
+          border-bottom-right-radius: 6px;
+          border-bottom-left-radius: 6px;
+          border-bottom: none;
         }
 
         &:hover {
           z-index: 1;
           color: #212529;
-          background-color: #f8f9fa;
+          background-color: #f5f8ff;
         }
 
         &.selected {
           z-index: 2;
-          color: #000;
-          background-color: #ffc107;
-          border-color: #ffc107;
+          color: #1a1a1a;
+          background-color: #e8f0fe;
+          border-color: #c5d7fb;
         }
 
         span.typed {
-          background-color: $warning-color;
-          padding: 0 2px;
+          font-weight: 600;
+          color: #1a73e8;
+          background-color: transparent;
+          padding: 0;
         }
       }
     }
   }
+
   .input-group-append {
     button {
       border-radius: 0;
@@ -117,41 +129,64 @@ $warning-color: #ffc107;
 .translate-list {
   display: flex;
   flex-wrap: wrap;
-  margin: 0;
+  margin: 4px 0;
   padding: 0;
+  gap: 4px;
 
   .translate-list-item {
     display: flex;
     flex-direction: column;
     list-style-type: none;
-    margin: 2px;
-    padding: 3px 3px 0 10px;
-    border: solid 0.5px #b3b1b1;
-    background: #fffffb;
+    margin: 0;
+    padding: 6px 8px 6px 12px;
+    border: solid 1px $item-border;
+    border-radius: 6px;
+    background: $item-bg;
     position: relative;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      border-color: $item-hover-border;
+      box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    }
 
     .translate-list-item-words {
       display: flex;
       flex-direction: column;
+      gap: 2px;
+
       div {
         display: flex;
         justify-content: space-between;
+        align-items: baseline;
 
         .word {
           display: flex;
           flex-wrap: wrap;
           justify-content: flex-start;
+          font-size: 0.9rem;
+
           span {
             cursor: pointer;
             &:hover {
               text-decoration: underline;
+              color: #1a73e8;
             }
           }
         }
+
         .culture {
-          margin-left: 6px;
-          color: #d3d3d3;
+          margin-left: 8px;
+          font-size: 0.65rem;
+          color: #fff;
+          background-color: $culture-color;
+          border-radius: 10px;
+          padding: 1px 6px;
+          font-weight: 500;
+          letter-spacing: 0.03em;
+          white-space: nowrap;
           align-self: center;
+          flex-shrink: 0;
         }
       }
     }
@@ -160,11 +195,12 @@ $warning-color: #ffc107;
       display: none;
       align-self: flex-end;
       position: absolute;
-      top: 8px;
-      right: 8px;
+      top: 6px;
+      right: 6px;
+
       svg {
-        height: 15px;
-        width: 15px;
+        height: 14px;
+        width: 14px;
       }
     }
 
@@ -173,14 +209,24 @@ $warning-color: #ffc107;
     }
 
     &.is-phrase {
-      background-color: red;
+      background-color: $phrase-bg;
+      border-color: #d8e8c0;
+
+      &:hover {
+        border-color: #b8d494;
+      }
+
       .translate-list-item-words {
         div {
-          border-bottom: dotted 0.2px #d3d3d3;
+          border-bottom: dotted 1px #d3d3d3;
           &:last-child {
             border-bottom: none;
           }
         }
+      }
+
+      .culture {
+        background-color: #8bbc5a;
       }
     }
   }

--- a/src/features/search/Search.tsx
+++ b/src/features/search/Search.tsx
@@ -130,7 +130,7 @@ const Search: React.FC = () => {
 
     return (
         <div className="d-flex flex-column">
-            <div className="sticky-top d-flex mb-1 flex-column w-100 bg-white">
+            <div className="sticky-top d-flex mb-2 flex-column w-100 bg-white search-header">
                 <div className="input-group">
                     <button className="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">{currentLanguage.cultureName}</button>
                     <ul className="dropdown-menu">

--- a/src/index.scss
+++ b/src/index.scss
@@ -22,9 +22,23 @@ $btn-focus-box-shadow: none;
 
 // scroll bar style
 ::-webkit-scrollbar {
-  width: 2px;
+  width: 4px;
+  height: 4px;
 }
- 
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 ::-webkit-scrollbar-thumb {
-  background: #d6dadd;
+  background: #d0d4d8;
+  border-radius: 2px;
+
+  &:hover {
+    background: #b0b5ba;
+  }
+}
+
+body {
+  background-color: #ffffff;
 }


### PR DESCRIPTION
- Fix phrase item background color (was incorrectly red, now uses #fafcf3)
- Translate list items: rounded corners, hover shadow, gap-based layout
- Culture labels: redesigned as small pill badges with background color
- Phrase items: green pill badge and soft green border instead of red bg
- Autocomplete dropdown: rounded, box-shadow, blue highlight replaces yellow
- Autocomplete typed text: bold blue instead of yellow highlight
- Sidebar: widened to 160px, light background, border separator, fade animation
- Sidebar buttons: full-width, left-aligned, subtle blue hover state
- Search header: sticky bar gets soft bottom shadow on scroll
- Scrollbar: slightly wider (4px), rounded thumb, hover darkening
- Global: clean body background

https://claude.ai/code/session_01Fez1kPDLo9YS4kP1FB6HxH